### PR TITLE
Remove network access

### DIFF
--- a/com.xnview.XnConvert.yaml
+++ b/com.xnview.XnConvert.yaml
@@ -9,8 +9,6 @@ finish-args:
   - --socket=x11
   # Filesystem access
   - --filesystem=home
-  # Network access
-  - --share=network
   # OpenGL access
   - --device=dri
 tags:


### PR DESCRIPTION
The integrated update notifier seems to only require it but updates are pushed over Flathub